### PR TITLE
feat(selfhosted): add firefly3 deployment

### DIFF
--- a/kubernetes/apps/selfhosted/firefly3/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: firefly3
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: firefly3
+      app.kubernetes.io/instance: firefly3
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            gateway.networking.k8s.io/gateway-name: envoy-brauni-dev-public
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: selfhosted
+            app.kubernetes.io/name: firefly3-cron
+            app.kubernetes.io/instance: firefly3
+            app.kubernetes.io/component: cron
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/firefly3/app/cronjob.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/cronjob.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/batch/v1/cronjob.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: firefly3-cron
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: firefly3-cron
+            app.kubernetes.io/instance: firefly3
+            app.kubernetes.io/component: cron
+        spec:
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: firefly3-cron
+              image: ghcr.io/home-operations/busybox:1.37.0@sha256:026ed7273270ec08f6902b4ae8334c23b473e5394bec3bbbdbfe580c710d50bc
+              command:
+                - /bin/sh
+                - -ec
+                - wget -qO- "http://firefly3:8080/api/v1/cron/${STATIC_CRON_TOKEN}" && printf '\n'
+              env:
+                - name: STATIC_CRON_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: firefly3-secret
+                      key: STATIC_CRON_TOKEN
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+          restartPolicy: OnFailure

--- a/kubernetes/apps/selfhosted/firefly3/app/dnsendpoints.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/dnsendpoints.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: firefly3
+  annotations:
+    dns.scope: all
+spec:
+  endpoints:
+    - dnsName: firefly3.brauni.dev
+      recordType: CNAME
+      targets:
+        - public.brauni.dev

--- a/kubernetes/apps/selfhosted/firefly3/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly3
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  target:
+    name: firefly3-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        APP_KEY: "{{ .app_key }}"
+        STATIC_CRON_TOKEN: "{{ .static_cron_token }}"
+  dataFrom:
+    - extract:
+        key: firefly3

--- a/kubernetes/apps/selfhosted/firefly3/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/helmrelease.yaml
@@ -1,0 +1,149 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app firefly3
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: firefly3
+  interval: 30m
+  driftDetection:
+    mode: enabled
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 33
+        runAsGroup: 33
+        fsGroup: 33
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      firefly3:
+        annotations:
+          reloader.stakater.com/auto: "true"
+          secret.reloader.stakater.com/reload: firefly3-secret,firefly3-pguser-secret
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: firefly3-initdb-secret
+        containers:
+          app:
+            image:
+              repository: docker.io/fireflyiii/core
+              tag: latest@sha256:6ae1b92eb73b4ae8a8e7e038440b93fba46267e05b5b903c62316b8cb03779af
+            env:
+              APP_ENV: production
+              APP_DEBUG: "false"
+              APP_URL: https://firefly3.brauni.dev
+              AUTHENTICATION_GUARD: web
+              COOKIE_SECURE: "true"
+              DB_CONNECTION: pgsql
+              DB_HOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: &pguser firefly3-pguser-secret
+                    key: host
+              DB_PORT:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: port
+              DB_DATABASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: db
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: user
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: password
+              LOG_CHANNEL: stdout
+              PGSQL_SSL_MODE: disable
+              TZ: Europe/Berlin
+              TRUSTED_PROXIES: "**"
+            envFrom:
+              - secretRef:
+                  name: firefly3-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 6
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      app:
+        controller: firefly3
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+            url: https://firefly3.brauni.dev
+        hostnames:
+          - firefly3.brauni.dev
+        parentRefs:
+          - name: envoy-brauni-dev-public
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+
+    persistence:
+      storage:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        storageClass: ceph-block
+        size: 5Gi
+        globalMounts:
+          - path: /var/www/html/storage

--- a/kubernetes/apps/selfhosted/firefly3/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./cronjob.yaml
+  - ./dnsendpoints.yaml
+  - ./ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/selfhosted/firefly3/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: firefly3
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/firefly3/ks.yaml
+++ b/kubernetes/apps/selfhosted/firefly3/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly3
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: dbms
+    - name: bitwarden
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/selfhosted/firefly3/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/selfhosted/homepage/app/configuration.yaml
+++ b/kubernetes/apps/selfhosted/homepage/app/configuration.yaml
@@ -85,6 +85,10 @@ data:
             href: https://atuin.brauni.dev
             siteMonitor: https://atuin.brauni.dev
             icon: mdi-console-line
+        - Firefly III:
+            href: https://firefly3.brauni.dev
+            siteMonitor: https://firefly3.brauni.dev
+            icon: mdi-cash-multiple
         - Decypharr:
             href: https://decypharr.riki.boo
             siteMonitor: https://decypharr.riki.boo

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - ./idlers/ks.yaml
   - ./immich/ks.yaml
   - ./atuin/ks.yaml
+  - ./firefly3/ks.yaml
   - ./paperless/ks.yaml


### PR DESCRIPTION
## Summary
- add a new `selfhosted/firefly3` Flux app backed by CNPG PostgreSQL and exposed at `https://firefly3.brauni.dev`
- include Firefly-specific secrets, persistent runtime storage, DNS, Gateway routing, and a cron job for scheduled Firefly tasks
- add the Firefly III entry to Homepage and wire the app into the selfhosted namespace kustomization

## Validation
- `bash util/check_drift_detection.sh`
- `kustomize build kubernetes/apps/selfhosted/firefly3/app`
- `docker run --rm --user \"$(id -u):$(id -g)\" -v \"/home/brauni/Repos/ovh-ops:/home/brauni/Repos/ovh-ops\" -w \"/home/brauni/Repos/ovh-ops/.worktrees/feature-firefly3-cnpg\" ghcr.io/allenporter/flux-local:v8.1.0 test --all-namespaces --enable-helm --path /home/brauni/Repos/ovh-ops/.worktrees/feature-firefly3-cnpg/kubernetes/flux/cluster --verbose`