### PR TITLE
feat(media): add jellyfin app with jellyfin.480p.com and jelly.480p.com

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/dnsendpoints.yaml
+++ b/kubernetes/apps/media/jellyfin/app/dnsendpoints.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: jellyfin
+  annotations:
+    dns.scope: all
+spec:
+  endpoints:
+    - dnsName: jellyfin.480p.com
+      recordType: CNAME
+      targets:
+        - public.480p.com
+    - dnsName: jelly.480p.com
+      recordType: CNAME
+      targets:
+        - public.480p.com

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -25,13 +25,47 @@ spec:
       jellyfin:
         annotations:
           reloader.stakater.com/auto: "true"
+          secret.reloader.stakater.com/reload: jellyfin-pguser-secret
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.3@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+            envFrom:
+              - secretRef:
+                  name: jellyfin-initdb-secret
         containers:
           app:
             image:
-              repository: docker.io/jellyfin/jellyfin
-              tag: 10.10.7@sha256:3b38dae4c3ddd6ebc7378538fba4d3f314070ebefbdb3d688166b7c8658fb123
+              repository: ghcr.io/jpvenson/jellyfin.pgsql
+              tag: 10.11.6-1@sha256:69d691ef7cc2ce438576af85b42ec0c5048f91e7283bf34e6533923331077cba
             env:
               JELLYFIN_PublishedServerUrl: https://jellyfin.480p.com
+              POSTGRES_HOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: &pguser jellyfin-pguser-secret
+                    key: host
+              POSTGRES_PORT:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: port
+              POSTGRES_DB:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: db
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: user
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: *pguser
+                    key: password
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jellyfin
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: jellyfin
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 44
+    controllers:
+      jellyfin:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/jellyfin/jellyfin
+              tag: 10.10.7@sha256:3b38dae4c3ddd6ebc7378538fba4d3f314070ebefbdb3d688166b7c8658fb123
+            env:
+              JELLYFIN_PublishedServerUrl: https://jellyfin.480p.com
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8096
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        controller: jellyfin
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Jellyfin
+          gethomepage.dev/pod-selector: app.kubernetes.io/name=jellyfin
+          gethomepage.dev/icon: jellyfin.png
+        hostnames:
+          - jellyfin.480p.com
+          - jelly.480p.com
+        parentRefs:
+          - name: envoy-480p-com-public
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: jellyfin
+                port: *port
+    persistence:
+      config:
+        existingClaim: jellyfin
+      cache:
+        existingClaim: jellyfin-cache
+      logs:
+        type: emptyDir
+      transcode:
+        type: emptyDir
+      tmp:
+        type: emptyDir
+      symlinks:
+        existingClaim: symlinks
+        globalMounts:
+          - path: /aio/symlinks
+      realdebrid:
+        type: custom
+        volumeSpec:
+          csi:
+            driver: rclone.csi.veloxpack.io
+            readOnly: true
+            volumeAttributes:
+              remote: decypharr
+              remotePath: "/"
+              dir-cache-time: "10s"
+              vfs-cache-mode: full
+              vfs-cache-max-age: "504h"
+              vfs-cache-max-size: "10G"
+              vfs-cache-poll-interval: "30s"
+              vfs-read-chunk-size: "32M"
+              vfs-read-chunk-size-limit: "128M"
+              vfs-fast-fingerprint: "true"
+              no-modtime: "true"
+              no-checksum: "true"
+              read-only: "true"
+              configData: |
+                [decypharr]
+                type = webdav
+                url = http://decypharr.media.svc.cluster.local:8282/webdav
+                vendor = other
+        globalMounts:
+          - path: /aio/remote/realdebrid
+            readOnly: true

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./pvc-cache.yaml
+  - ./helmrelease.yaml
+  - ./dnsendpoints.yaml

--- a/kubernetes/apps/media/jellyfin/app/ocirepository.yaml
+++ b/kubernetes/apps/media/jellyfin/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: jellyfin
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/jellyfin/app/pvc-cache.yaml
+++ b/kubernetes/apps/media/jellyfin/app/pvc-cache.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: openebs-hostpath

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jellyfin
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: openebs
+      namespace: openebs-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: symlinks
+    - name: decypharr
+    - name: csi-rclone
+      namespace: csi-rclone
+  interval: 1h
+  path: ./kubernetes/apps/media/jellyfin/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 25Gi
+      VOLSYNC_CACHE_CAPACITY: 25Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -10,14 +10,21 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
+    - ../../../../components/cnpg
     - ../../../../components/volsync
   dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: dbms
+    - name: bitwarden
+      namespace: external-secrets
     - name: openebs
       namespace: openebs-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: symlinks
+      namespace: media
     - name: decypharr
+      namespace: media
     - name: csi-rclone
       namespace: csi-rclone
   interval: 1h
@@ -25,6 +32,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      CNPG_NAME: postgres18
       VOLSYNC_CAPACITY: 25Gi
       VOLSYNC_CACHE_CAPACITY: 25Gi
   prune: true

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./cleanuparr/ks.yaml
   - ./comet/ks.yaml
   - ./decypharr/ks.yaml
+  - ./jellyfin/ks.yaml
   - ./kometa/ks.yaml
   - ./media-debug/ks.yaml
   - ./newtarr/ks.yaml


### PR DESCRIPTION
## Summary
- add new `media/jellyfin` app (Flux ks + app manifests)
- expose Jellyfin via Gateway route on:
  - `jellyfin.480p.com`
  - `jelly.480p.com`
- add `DNSEndpoint` records for both hostnames
- mirror Plex media folder access pattern (symlinks + decypharr WebDAV mount)
- switch Jellyfin to experimental PostgreSQL-enabled image:
  - `ghcr.io/jpvenson/jellyfin.pgsql:10.11.6-1@sha256:69d691ef7cc2ce438576af85b42ec0c5048f91e7283bf34e6533923331077cba`
- wire CNPG component and secrets (`jellyfin-initdb-secret`, `jellyfin-pguser-secret`)

## Notes
- this PR is intentionally opened as **draft** for later review/merge
- Jellyfin PostgreSQL path is unofficial/experimental upstream
- no in-cluster reconcile was triggered
