### PR TITLE
feat(selfhosted): add networking-toolbox app

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./opencloud/ks.yaml
   - ./open-webui/ks.yaml
   - ./web-check/ks.yaml
+  - ./networking-toolbox/ks.yaml
   - ./karakeep/ks.yaml
   - ./idlers/ks.yaml
   - ./immich/ks.yaml

--- a/kubernetes/apps/selfhosted/networking-toolbox/app/dnsendpoints.yaml
+++ b/kubernetes/apps/selfhosted/networking-toolbox/app/dnsendpoints.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: networking-toolbox
+  annotations:
+    dns.scope: all
+spec:
+  endpoints:
+    - dnsName: networking-toolbox.brauni.dev
+      recordType: CNAME
+      targets:
+        - public.brauni.dev
+    - dnsName: net-tools.brauni.dev
+      recordType: CNAME
+      targets:
+        - public.brauni.dev

--- a/kubernetes/apps/selfhosted/networking-toolbox/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/networking-toolbox/app/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app networking-toolbox
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: networking-toolbox
+  interval: 30m
+  driftDetection:
+    mode: enabled
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    controllers:
+      networking-toolbox:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/lissy93/networking-toolbox
+              tag: 1.6.0@sha256:4e97330fb310e1a5fbe185b1bf859270902ddef7934b88cecc6b3def98d21eaa
+            env:
+              PORT: "3000"
+              HOST: 0.0.0.0
+              NODE_ENV: production
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      app:
+        controller: networking-toolbox
+        primary: true
+        ports:
+          http:
+            port: 3000
+
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+            url: https://net-tools.brauni.dev/health
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Tools
+          gethomepage.dev/name: Networking Toolbox
+          gethomepage.dev/pod-selector: app.kubernetes.io/name=networking-toolbox
+          gethomepage.dev/icon: mdi-lan
+        hostnames:
+          - networking-toolbox.brauni.dev
+          - net-tools.brauni.dev
+        parentRefs:
+          - name: envoy-brauni-dev-public
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: 3000
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/selfhosted/networking-toolbox/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/networking-toolbox/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./dnsendpoints.yaml

--- a/kubernetes/apps/selfhosted/networking-toolbox/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/networking-toolbox/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: networking-toolbox
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/networking-toolbox/ks.yaml
+++ b/kubernetes/apps/selfhosted/networking-toolbox/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app networking-toolbox
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/selfhosted/networking-toolbox/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
- add `networking-toolbox` app under `kubernetes/apps/selfhosted`
- deploy with bjw-s `app-template` (`OCIRepository` + `HelmRelease`)
- expose via Gateway API route and ExternalDNS
- add Homepage discovery annotations
- add hostnames `networking-toolbox.brauni.dev` and `net-tools.brauni.dev`
- pin image to digest (`lissy93/networking-toolbox:1.6.0@sha256:4e97330fb310e1a5fbe185b1bf859270902ddef7934b88cecc6b3def98d21eaa`)

## Validation
- `kustomize build kubernetes/apps/selfhosted/networking-toolbox/app`
- `kustomize build kubernetes/apps/selfhosted`
- `bash util/check_drift_detection.sh`
