### PR TITLE
fix(patchmon): add Host header to kubelet probes to bypass CORS host …

### DIFF
--- a/kubernetes/apps/selfhosted/patchmon/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/patchmon/app/helmrelease.yaml
@@ -74,6 +74,9 @@ spec:
                   httpGet:
                     path: /health
                     port: 3000
+                    httpHeaders:
+                      - name: Host
+                        value: patchmon.riki.boo
               readiness:
                 enabled: true
                 custom: true
@@ -81,6 +84,9 @@ spec:
                   httpGet:
                     path: /health
                     port: 3000
+                    httpHeaders:
+                      - name: Host
+                        value: patchmon.riki.boo
               startup:
                 enabled: true
                 custom: true
@@ -90,6 +96,9 @@ spec:
                   httpGet:
                     path: /health
                     port: 3000
+                    httpHeaders:
+                      - name: Host
+                        value: patchmon.riki.boo
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
…check

patchmon-server:2.0.0's CORS middleware validates the Host header on all requests, including Kubernetes health probes. Kubelet sends the pod IP as Host, which doesn't match CORS_ORIGIN, causing 403 Forbidden.

Add an explicit 'Host: patchmon.riki.boo' header to liveness, readiness, and startup probes so they pass the CORS middleware.