### PR TITLE
feat(selfhosted): add vaultwarden

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - ./firefly3/ks.yaml
   - ./paperless/ks.yaml
   - ./patchmon/ks.yaml
+  - ./vaultwarden/ks.yaml

--- a/kubernetes/apps/selfhosted/vaultwarden/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vaultwarden
+      app.kubernetes.io/instance: vaultwarden
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            gateway.networking.k8s.io/gateway-name: envoy-brauni-dev-public
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/vaultwarden/app/dnsendpoints.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/dnsendpoints.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: vaultwarden
+  annotations:
+    dns.scope: all
+spec:
+  endpoints:
+    - dnsName: vaultwarden.brauni.dev
+      recordType: CNAME
+      targets:
+        - public.brauni.dev

--- a/kubernetes/apps/selfhosted/vaultwarden/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden
+  target:
+    name: vaultwarden-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ADMIN_TOKEN: "{{ .ADMIN_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: vaultwarden

--- a/kubernetes/apps/selfhosted/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/helmrelease.yaml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app vaultwarden
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: vaultwarden
+  interval: 30m
+  driftDetection:
+    mode: enabled
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      vaultwarden:
+        annotations:
+          reloader.stakater.com/auto: "true"
+          secret.reloader.stakater.com/reload: vaultwarden-secret,vaultwarden-pguser-secret
+        initContainers:
+          01-init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.4@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+            envFrom:
+              - secretRef:
+                  name: vaultwarden-initdb-secret
+        containers:
+          app:
+            image:
+              repository: docker.io/vaultwarden/server
+              tag: 1.36.0@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
+            env:
+              DOMAIN: https://vaultwarden.brauni.dev
+              ROCKET_PORT: &port 80
+              SIGNUPS_ALLOWED: "true"
+              WEBSOCKET_ENABLED: "false"
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: vaultwarden-pguser-secret
+                    key: uri
+            envFrom:
+              - secretRef:
+                  name: vaultwarden-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      app:
+        controller: vaultwarden
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+            url: https://vaultwarden.brauni.dev
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Selfhosted
+          gethomepage.dev/name: Vaultwarden
+          gethomepage.dev/pod-selector: app.kubernetes.io/name=vaultwarden
+          gethomepage.dev/icon: si-bitwarden-#175DDC
+        hostnames:
+          - vaultwarden.brauni.dev
+        parentRefs:
+          - name: envoy-brauni-dev-public
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+
+    persistence:
+      data:
+        existingClaim: *app
+        advancedMounts:
+          vaultwarden:
+            app:
+              - path: /data

--- a/kubernetes/apps/selfhosted/vaultwarden/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./dnsendpoints.yaml
+  - ./ciliumnetworkpolicy.yaml

--- a/kubernetes/apps/selfhosted/vaultwarden/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vaultwarden
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/vaultwarden/ks.yaml
+++ b/kubernetes/apps/selfhosted/vaultwarden/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vaultwarden
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/cnpg
+    - ../../../../components/volsync
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: dbms
+    - name: bitwarden
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/selfhosted/vaultwarden/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
Add Vaultwarden (Bitwarden-compatible server) to the selfhosted namespace.

## Changes
- **HelmRelease** with `vaultwarden/server:1.36.0` via bjw-s app-template v5.0.1
- PostgreSQL backend via shared CNPG component
- Persistent storage for `/data` via volsync (10Gi)
- ExternalSecret pulls `ADMIN_TOKEN` from Bitwarden
- DNSEndpoint, CiliumNetworkPolicy, and Homepage annotations
- Route exposed via `envoy-brauni-dev-public` at `vaultwarden.brauni.dev`

## Pre-merge checklist
- [ ] Add `vaultwarden` entry to Bitwarden with `ADMIN_TOKEN` field
- [ ] Add `vaultwarden_postgres_username` and `vaultwarden_postgres_password` to `cloudnative-pg` Bitwarden entry