### PR TITLE
feat(rook-ceph): upgrade to v1.20.0 with ceph-csi-drivers chart

### DIFF
--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -33,13 +33,7 @@ spec:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
-        clusterName: rook-ceph
-        fsGroupPolicy: File
-        imageSet:
-          name: rook-csi-operator-image-set-configmap
         controllerPlugin:
-          replicas: 2
-          priorityClassName: system-cluster-critical
           resources:
             attacher:
               limits:
@@ -77,7 +71,6 @@ spec:
                 cpu: 100m
                 memory: 128Mi
         nodePlugin:
-          priorityClassName: system-node-critical
           resources:
             plugin:
               limits:
@@ -96,17 +89,10 @@ spec:
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
-        clusterName: rook-ceph
-        fsGroupPolicy: File
         snapshotPolicy: volumeGroupSnapshot
-        cephFsClientType: kernel
         kernelMountOptions:
           ms_mode: prefer-crc
-        imageSet:
-          name: rook-csi-operator-image-set-configmap
         controllerPlugin:
-          replicas: 2
-          priorityClassName: system-cluster-critical
           resources:
             attacher:
               limits:
@@ -139,7 +125,6 @@ spec:
                 cpu: 100m
                 memory: 128Mi
         nodePlugin:
-          priorityClassName: system-node-critical
           resources:
             plugin:
               limits:

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -1,0 +1,161 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ceph-csi-drivers
+  interval: 1h
+  values:
+    # OperatorConfig defaults (inherited by all drivers)
+    operatorConfig:
+      driverSpecDefaults:
+        clusterName: rook-ceph
+        cephFsClientType: kernel
+        fsGroupPolicy: File
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          priorityClassName: system-cluster-critical
+          deploymentStrategy:
+            type: Recreate
+        nodePlugin:
+          priorityClassName: system-node-critical
+          kubeletDirPath: /var/lib/kubelet
+
+    drivers:
+      # RBD driver
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+        clusterName: rook-ceph
+        fsGroupPolicy: File
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        controllerPlugin:
+          replicas: 2
+          priorityClassName: system-cluster-critical
+          resources:
+            attacher:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            omapGenerator:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            plugin:
+              limits:
+                memory: 1Gi
+              requests:
+                memory: 512Mi
+            provisioner:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            resizer:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            snapshotter:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+        nodePlugin:
+          priorityClassName: system-node-critical
+          resources:
+            plugin:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            registrar:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 50m
+                memory: 128Mi
+
+      # CephFS driver
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        clusterName: rook-ceph
+        fsGroupPolicy: File
+        snapshotPolicy: volumeGroupSnapshot
+        cephFsClientType: kernel
+        kernelMountOptions:
+          ms_mode: prefer-crc
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        controllerPlugin:
+          replicas: 2
+          priorityClassName: system-cluster-critical
+          resources:
+            attacher:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            plugin:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            provisioner:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            resizer:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+            snapshotter:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+        nodePlugin:
+          priorityClassName: system-node-critical
+          resources:
+            plugin:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 512Mi
+            registrar:
+              limits:
+                memory: 256Mi
+              requests:
+                cpu: 50m
+                memory: 128Mi
+
+      # Disable unused drivers
+      nfs:
+        enabled: false
+      nvmeof:
+        enabled: false

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
@@ -2,12 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: rook-ceph
-
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  - ./ceph-csi-drivers/ks.yaml
-  - ./rook-ceph/ks.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
@@ -3,12 +3,12 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: rook-ceph
+  name: ceph-csi-drivers
 spec:
   interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.0
-  url: oci://ghcr.io/rook/rook-ceph
+    tag: 1.0.1
+  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -5,11 +5,20 @@ kind: Kustomization
 metadata:
   name: ceph-csi-drivers
 spec:
-  interval: 1h
+  interval: 30m
   path: ./kubernetes/apps/rook-ceph/ceph-csi-drivers/app
-  prune: true
+  prune: false
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   targetNamespace: rook-ceph
+  wait: true
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: ceph-csi-drivers
+      namespace: rook-ceph

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.brauni.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/ceph-csi-drivers/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: rook-ceph

--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -9,5 +9,5 @@ components:
 
 resources:
   - ./namespace.yaml
-  - ./ceph-csi-drivers/ks.yaml
   - ./rook-ceph/ks.yaml
+  - ./ceph-csi-drivers/ks.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -13,17 +13,11 @@ spec:
     mode: enabled
   values:
     csi:
-      enableRbdDriver: true
-      cephFSKernelMountOptions: ms_mode=prefer-crc
-      # NOTE: Enable the driver and shapshotter if you want to use CephFS
-      enableCephfsDriver: true
-      enableCephfsSnapshotter: true
-      enableLiveness: true
       serviceMonitor:
         enabled: true
     image:
       repository: ghcr.io/rook/ceph
-      tag: v1.19.6@sha256:eab4005612a6d10cac3d947f9846380ea13ecd2336c7397f519f0009578329c2
+      tag: v1.20.0@sha256:5e543abbab51acb0818f5b319bbd5e7ad435bfd8e011d4f532e6b9588ce6157d
     monitoring:
       enabled: true
     resources:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.0
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -36,6 +36,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: ceph-csi-drivers
+      namespace: rook-ceph
     - name: rook-ceph
       namespace: *namespace
   healthChecks:


### PR DESCRIPTION
## Summary

Upgrades Rook-Ceph from v1.19.6 to v1.20.0. This is a **breaking change** release that removes CSI driver configuration from the `rook-ceph` Helm chart.

## Breaking Change

Rook v1.20.0 requires CSI drivers to be managed via the `ceph-csi-drivers` chart from the ceph-csi-operator project. The CSI settings previously in the rook-ceph Helm chart values are now ignored.

## Changes

### New Files
- `kubernetes/apps/rook-ceph/ceph-csi-drivers/` - New Flux app for CSI driver management
  - `ks.yaml` - Flux Kustomization
  - `app/helmrelease.yaml` - HelmRelease with all current Driver CR settings preserved
  - `app/ocirepository.yaml` - Chart source (v1.0.1 from home-operations mirror)
  - `app/kustomization.yaml` - Kustomize resources

### Modified Files
- `kubernetes/apps/rook-ceph/kustomization.yaml` - Added ceph-csi-drivers ks.yaml reference
- `kubernetes/apps/rook-ceph/rook-ceph/ks.yaml` - Added `ceph-csi-drivers` dependency for `rook-ceph-cluster`
- `kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml` - Removed CSI settings (now in ceph-csi-drivers), updated image to v1.20.0
- `kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml` - Updated tag to v1.20.0
- `kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml` - Updated tag to v1.20.0

## Preserved Settings

All current CSI driver settings from the existing Driver CRs are preserved:

- **RBD Driver** (`rook-ceph.rbd.csi.ceph.com`)
  - `fsGroupPolicy: File`
  - `controllerPlugin.replicas: 2`
  - `controllerPlugin.priorityClassName: system-cluster-critical`
  - `nodePlugin.priorityClassName: system-node-critical`
  - All resource limits/requests

- **CephFS Driver** (`rook-ceph.cephfs.csi.ceph.com`)
  - `snapshotPolicy: volumeGroupSnapshot`
  - `kernelMountOptions.ms_mode: prefer-crc`
  - Same priority classes and resource settings as RBD

- **OperatorConfig** defaults
  - `controllerPlugin.hostNetwork: true`
  - `controllerPlugin.deploymentStrategy.type: Recreate`
  - `imageSet.name: rook-csi-operator-image-set-configmap`

## Reconciliation Order

Enforced by Flux dependencies:
1. `ceph-csi-drivers` - Creates/updates Driver CRs and OperatorConfig
2. `rook-ceph` - Operator upgrade
3. `rook-ceph-cluster` - Cluster upgrade

## Reference

Based on: https://github.com/buroa/k8s-gitops/commit/f9c7f3f284164a86cfa0ff3d645cd139981e430e

## Related PRs

This supersedes:
- #565 (container image update)
- #566 (chart version updates)
